### PR TITLE
fix card loading at the Custom cards list

### DIFF
--- a/src/air-comfort-card.ts
+++ b/src/air-comfort-card.ts
@@ -702,7 +702,7 @@ export class AirComfortCard extends LitElement implements LovelaceCard {
 // Register the card with Home Assistant
 (window as any).customCards = (window as any).customCards || [];
 (window as any).customCards.push({
-  type: "custom:air-comfort-card",
+  type: "air-comfort-card",
   name: "Air Comfort Card",
   description:
     "A card that visualizes indoor air comfort using temperature and humidity",


### PR DESCRIPTION
Problem: the card couldn't load at the Custom cards list.

> Unhandled Promise Rejection: Error: Custom element not found: custom:air-comfort-card


HA's card picker passes the type from window.customCards directly to customElements.whenDefined() without stripping the  custom: prefix. Changing type: "custom:air-comfort-card" to type: "air-comfort-card" in the registration fixed the mismatch.