### PR TITLE
improve a preview page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -94,7 +94,6 @@
       background: #1e1e1e;
       border-radius: 12px;
       border: 1px solid rgba(255, 255, 255, 0.05);
-      overflow: hidden;
     }
     .editor-container .section-label {
       padding: 16px 16px 0;


### PR DESCRIPTION
The playground now renders `<air-comfort-card-editor>` alongside the card previews, so the editor UI can be developed and tested in the browser without deploying to Home Assistant.

<img width="883" height="818" alt="image" src="https://github.com/user-attachments/assets/2fa3fbcb-6846-4785-8963-335d5d04b088" />
