### PR TITLE
use same direction mapping in comfort-zone as outside-zone

### DIFF
--- a/src/comfort-zone.ts
+++ b/src/comfort-zone.ts
@@ -74,7 +74,8 @@ export function calculateComfortZone(
     const idealHumidity = (humidityMin + humidityMax) / 2;
     const tempOffset = temp - idealTemp;
     const humidityOffset = humidity - idealHumidity;
-    angle = Math.atan2(humidityOffset, tempOffset) * (180 / Math.PI);
+    // Use same direction mapping as outside-zone: warm=top(0°), humid=right(90°), cold=bottom(180°), dry=left(270°)
+    angle = Math.atan2(-tempOffset, humidityOffset) * (180 / Math.PI);
     angle = (angle + 90 + 360) % 360;
   } else {
     // Calculate angle based on actual deviations, not just direction


### PR DESCRIPTION
This PR improves the comfort zone indicator's visual consistency and accuracy by aligning the direction mapping inside the comfort zone with the outside-zone behavior and introducing a continuous distance-based positioning system.

**Changes:**
- Fixed angle calculation inside comfort zone to use the same direction mapping as outside zone (warm=top/0°, humid=right/90°, cold=bottom/180°, dry=left/270°)
- Replaced fixed-ratio indicator positioning with Chebyshev (box) distance calculation for smooth continuous positioning from center to zone boundary
- Removed the COMFORT_ZONE_VARIATION constant in favor of dynamic distance-based positioning

<img width="527" height="645" alt="image" src="https://github.com/user-attachments/assets/423fa334-2154-4f5b-8ce2-b2a225657a9f" />
