### PR TITLE
replace chart.js with custom SVG in Lit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,6 @@
     "": {
       "name": "ha-air-comfort-card",
       "dependencies": {
-        "chart.js": "4.5.1",
-        "chartjs-adapter-date-fns": "3.0.0",
-        "date-fns": "4.1.0",
         "lit": "^2.6.1",
       },
       "devDependencies": {
@@ -48,8 +45,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
@@ -125,10 +120,6 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "chart.js": ["chart.js@4.5.1", "", { "dependencies": { "@kurkle/color": "^0.3.0" } }, "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw=="],
-
-    "chartjs-adapter-date-fns": ["chartjs-adapter-date-fns@3.0.0", "", { "peerDependencies": { "chart.js": ">=2.8.0", "date-fns": ">=2.0.0" } }, "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg=="],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -138,8 +129,6 @@
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
-    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "chart.js": "4.5.1",
-    "chartjs-adapter-date-fns": "3.0.0",
-    "date-fns": "4.1.0",
     "lit": "^2.6.1"
   }
 }

--- a/src/air-comfort-card.ts
+++ b/src/air-comfort-card.ts
@@ -1,12 +1,5 @@
-import { LitElement, html, PropertyValues } from "lit";
+import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import {
-  Chart,
-  ChartConfiguration,
-  registerables,
-  ScatterDataPoint
-} from "chart.js";
-import "chartjs-adapter-date-fns";
 import { CardConfig, HomeAssistant, HistoryState, LovelaceCard, stripDeprecatedKeys } from "./types";
 import { cardStyles } from "./styles";
 import { calculateComfortZone, celsiusToFahrenheit, fahrenheitToCelsius } from "./comfort-zone";
@@ -14,32 +7,26 @@ import { calculateAirQuality, AQ_THRESHOLDS, SensorReading } from "./air-quality
 import { dominantStatus } from "./status";
 import { getTranslations } from "./translations";
 import "./air-comfort-card-editor";
-
-Chart.register(...registerables);
-
-interface ChartDataPoint {
-  time: Date;
-  value: number;
-}
+import { SvgChartPoint, SvgChartThreshold } from "./svg-chart";
+import "./svg-chart";
 
 @customElement("air-comfort-card")
 export class AirComfortCard extends LitElement implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
   @state() private config?: CardConfig;
   @state() private dialSize = 280;
-  @state() private temperatureHistory: ChartDataPoint[] = [];
-  @state() private humidityHistory: ChartDataPoint[] = [];
-  @state() private co2History: ChartDataPoint[] = [];
-  @state() private no2History: ChartDataPoint[] = [];
-  @state() private pm1History: ChartDataPoint[] = [];
-  @state() private pm25History: ChartDataPoint[] = [];
-  @state() private pm10History: ChartDataPoint[] = [];
-  @state() private radonHistory: ChartDataPoint[] = [];
-  @state() private vocHistory: ChartDataPoint[] = [];
+  @state() private temperatureHistory: SvgChartPoint[] = [];
+  @state() private humidityHistory: SvgChartPoint[] = [];
+  @state() private co2History: SvgChartPoint[] = [];
+  @state() private no2History: SvgChartPoint[] = [];
+  @state() private pm1History: SvgChartPoint[] = [];
+  @state() private pm25History: SvgChartPoint[] = [];
+  @state() private pm10History: SvgChartPoint[] = [];
+  @state() private radonHistory: SvgChartPoint[] = [];
+  @state() private vocHistory: SvgChartPoint[] = [];
   @state() private historyExpanded = false;
 
   private resizeObserver?: ResizeObserver;
-  private charts = new Map<string, Chart>();
   private historyFetchInterval?: number;
   private lastHistoryFetch = 0;
 
@@ -119,44 +106,7 @@ export class AirComfortCard extends LitElement implements LovelaceCard {
     if (this.historyFetchInterval) {
       clearInterval(this.historyFetchInterval);
     }
-    this.destroyCharts();
     super.disconnectedCallback();
-  }
-
-  protected updated(changedProperties: PropertyValues): void {
-    super.updated(changedProperties);
-    const chartDataChanged =
-      changedProperties.has("temperatureHistory") ||
-      changedProperties.has("humidityHistory") ||
-      changedProperties.has("co2History") ||
-      changedProperties.has("no2History") ||
-      changedProperties.has("pm1History") ||
-      changedProperties.has("pm25History") ||
-      changedProperties.has("pm10History") ||
-      changedProperties.has("radonHistory") ||
-      changedProperties.has("vocHistory") ||
-      changedProperties.has("config");
-
-    if (changedProperties.has("historyExpanded")) {
-      if (this.historyExpanded) {
-        this.updateCharts();
-      } else {
-        this.destroyCharts();
-      }
-    } else if (this.historyExpanded && chartDataChanged) {
-      // Recreate charts when config changes so threshold lines update
-      if (changedProperties.has("config")) {
-        this.destroyCharts();
-      }
-      this.updateCharts();
-    }
-  }
-
-  private destroyCharts(): void {
-    for (const chart of this.charts.values()) {
-      chart.destroy();
-    }
-    this.charts.clear();
   }
 
   private async fetchHistory(): Promise<void> {
@@ -210,7 +160,7 @@ export class AirComfortCard extends LitElement implements LovelaceCard {
       for (const entityHistory of history) {
         if (entityHistory.length === 0) continue;
 
-        const points: ChartDataPoint[] = entityHistory
+        const points: SvgChartPoint[] = entityHistory
           .filter(s => !isNaN(parseFloat(s.state)))
           .map(s => ({
             time: new Date(s.last_changed),
@@ -244,164 +194,16 @@ export class AirComfortCard extends LitElement implements LovelaceCard {
     }
   }
 
-  private getChartConfig(
-    data: ChartDataPoint[],
-    label: string,
-    color: string,
-    unit: string,
-    thresholds?: { value: number; color: string; label?: string }[]
-  ): ChartConfiguration {
-    const datasetPoints: ScatterDataPoint[] = data.map(point => ({
-      x: point.time.getTime(),
-      y: point.value
-    }));
-
-    const plugins: ChartConfiguration["plugins"] = [];
-    if (thresholds && thresholds.length > 0) {
-      plugins.push({
-        id: "thresholdLines",
-        afterDatasetsDraw(chart: Chart) {
-          const { ctx, chartArea, scales } = chart;
-          const yScale = scales.y;
-          if (!yScale || !chartArea) return;
-
-          ctx.save();
-
-          for (const threshold of thresholds) {
-            const yMin = yScale.min as number;
-            const yMax = yScale.max as number;
-            if (threshold.value < yMin || threshold.value > yMax) continue;
-            const y = yScale.getPixelForValue(threshold.value);
-
-            ctx.setLineDash([6, 4]);
-            ctx.lineWidth = 1;
-            ctx.strokeStyle = threshold.color;
-            ctx.beginPath();
-            ctx.moveTo(chartArea.left, y);
-            ctx.lineTo(chartArea.right, y);
-            ctx.stroke();
-
-            if (threshold.label) {
-              ctx.setLineDash([]);
-              ctx.font = "10px sans-serif";
-              ctx.fillStyle = threshold.color;
-              ctx.textAlign = "right";
-              ctx.fillText(
-                threshold.label,
-                chartArea.right - 4,
-                y - 4
-              );
-            }
-          }
-
-          ctx.restore();
-        }
-      });
-    }
-
-    return {
-      type: "line",
-      data: {
-        datasets: [
-          {
-            label,
-            data: datasetPoints,
-            borderColor: color,
-            backgroundColor: color + "33",
-            fill: true,
-            tension: 0.4,
-            pointRadius: 0,
-            borderWidth: 2
-          }
-        ]
-      },
-      plugins,
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: {
-          intersect: false,
-          mode: "index"
-        },
-        plugins: {
-          legend: {
-            display: false
-          },
-          tooltip: {
-            callbacks: {
-              title: tooltipItems => {
-                const tooltipItem = tooltipItems[0];
-                if (!tooltipItem) {
-                  return "";
-                }
-                const parsedX = tooltipItem.parsed.x;
-                const timestamp =
-                  typeof parsedX === "number"
-                    ? parsedX
-                    : typeof (tooltipItem.raw as { x?: number })?.x ===
-                      "number"
-                    ? (tooltipItem.raw as { x: number }).x
-                    : undefined;
-                if (typeof timestamp !== "number") {
-                  return "";
-                }
-                const date = new Date(timestamp);
-                if (Number.isNaN(date.getTime())) {
-                  return "";
-                }
-                return date.toLocaleTimeString([], {
-                  hour: "2-digit",
-                  minute: "2-digit"
-                });
-              },
-              label: context => {
-                return `${context.parsed.y?.toFixed(1) ?? ""}${unit}`;
-              }
-            }
-          }
-        },
-        scales: {
-          x: {
-            type: "time",
-            time: {
-              unit: "hour",
-              displayFormats: {
-                hour: "HH:mm"
-              }
-            },
-            grid: {
-              color: "rgba(255,255,255,0.1)"
-            },
-            ticks: {
-              color: "rgba(255,255,255,0.6)",
-              maxTicksLimit: 6
-            }
-          },
-          y: {
-            grid: {
-              color: "rgba(255,255,255,0.1)"
-            },
-            ticks: {
-              color: "rgba(255,255,255,0.6)",
-              callback: value => `${Math.round(Number(value))}${unit}`
-            }
-          }
-        }
-      }
-    };
-  }
-
-private getSensorDefs() {
+  private getSensorDefs() {
     const config = this.config;
     if (!config) return [];
 
     const tr = getTranslations(this.hass?.language);
 
-    type Threshold = { value: number; color: string; label: string };
-    const thresh = (value: number | undefined, color: string, label: string): Threshold | null =>
+    const thresh = (value: number | undefined, color: string, label: string): SvgChartThreshold | null =>
       value != null ? { value, color, label } : null;
-    const collect = (...items: (Threshold | null)[]): Threshold[] =>
-      items.filter((t): t is Threshold => t !== null);
+    const collect = (...items: (SvgChartThreshold | null)[]): SvgChartThreshold[] =>
+      items.filter((t): t is SvgChartThreshold => t !== null);
 
     const entityUnit = (entityKey: keyof CardConfig, fallback: string): string => {
       const id = config[entityKey] as string | undefined;
@@ -423,7 +225,7 @@ private getSensorDefs() {
 
     return [
       {
-        id: "temperature", canvasId: "temp-chart",
+        id: "temperature",
         label: tr.sensors.temperature, color: "#ff6b6b",
         unit: displayTempUnit, history: tempHistory,
         show: true,
@@ -433,7 +235,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "humidity", canvasId: "humidity-chart",
+        id: "humidity",
         label: tr.sensors.humidity, color: "#4dabf7",
         unit: entityUnit("humidity_entity", "%"), history: this.humidityHistory,
         show: true,
@@ -443,7 +245,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "co2", canvasId: "co2-chart",
+        id: "co2",
         label: tr.sensors.co2, color: "#a9e34b",
         unit: entityUnit("co2_entity", "ppm"), history: this.co2History,
         show: !!config.co2_entity,
@@ -454,7 +256,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "no2", canvasId: "no2-chart",
+        id: "no2",
         label: tr.sensors.no2, color: "#ffa94d",
         unit: entityUnit("no2_entity", ""), history: this.no2History,
         show: !!config.no2_entity,
@@ -465,7 +267,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "pm1", canvasId: "pm1-chart",
+        id: "pm1",
         label: tr.sensors.pm1, color: "#e599f7",
         unit: entityUnit("pm1_entity", "µg/m³"), history: this.pm1History,
         show: !!config.pm1_entity,
@@ -476,7 +278,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "pm25", canvasId: "pm25-chart",
+        id: "pm25",
         label: tr.sensors.pm25, color: "#da77f2",
         unit: entityUnit("pm25_entity", "µg/m³"), history: this.pm25History,
         show: !!config.pm25_entity,
@@ -487,7 +289,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "pm10", canvasId: "pm10-chart",
+        id: "pm10",
         label: tr.sensors.pm10, color: "#74c0fc",
         unit: entityUnit("pm10_entity", "µg/m³"), history: this.pm10History,
         show: !!config.pm10_entity,
@@ -498,7 +300,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "radon", canvasId: "radon-chart",
+        id: "radon",
         label: tr.sensors.radon, color: "#63e6be",
         unit: entityUnit("radon_entity", "Bq/m³"), history: this.radonHistory,
         show: !!config.radon_entity,
@@ -509,7 +311,7 @@ private getSensorDefs() {
         ),
       },
       {
-        id: "voc", canvasId: "voc-chart",
+        id: "voc",
         label: tr.sensors.voc, color: "#20c997",
         unit: entityUnit("voc_entity", ""), history: this.vocHistory,
         show: !!config.voc_entity,
@@ -520,29 +322,6 @@ private getSensorDefs() {
         ),
       },
     ];
-  }
-
-  private updateCharts(): void {
-    for (const def of this.getSensorDefs()) {
-      const canvas = this.shadowRoot?.getElementById(def.canvasId) as HTMLCanvasElement | null;
-
-      if (!canvas) {
-        this.charts.get(def.id)?.destroy();
-        this.charts.delete(def.id);
-        continue;
-      }
-
-      if (def.history.length === 0) continue;
-
-      const chartConfig = this.getChartConfig(def.history, def.label, def.color, def.unit, def.thresholds);
-      const existing = this.charts.get(def.id);
-      if (existing) {
-        existing.data = chartConfig.data;
-        existing.update("none");
-      } else {
-        this.charts.set(def.id, new Chart(canvas, chartConfig));
-      }
-    }
   }
 
   private updateDialSize(width: number): void {
@@ -822,9 +601,12 @@ private getSensorDefs() {
                 ${visibleDefs.map(def => html`
                   <div class="chart-wrapper">
                     <div class="chart-label">${def.label} ${t.history.chartSuffix}</div>
-                    <div class="chart-canvas-container">
-                      <canvas id="${def.canvasId}"></canvas>
-                    </div>
+                    <svg-line-chart
+                      .data=${def.history}
+                      .color=${def.color}
+                      .unit=${def.unit}
+                      .thresholds=${def.thresholds}
+                    ></svg-line-chart>
                   </div>
                 `)}
               </div>

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -348,14 +348,8 @@ export const cardStyles = css`
     letter-spacing: 0.1em;
   }
 
-  .chart-canvas-container {
-    position: relative;
-    height: 120px;
+  svg-line-chart {
+    display: block;
     width: 100%;
-  }
-
-  .chart-canvas-container canvas {
-    width: 100% !important;
-    height: 100% !important;
   }
 `;

--- a/src/svg-chart.ts
+++ b/src/svg-chart.ts
@@ -1,0 +1,359 @@
+import { LitElement, html, svg, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+export interface SvgChartPoint {
+  time: Date;
+  value: number;
+}
+
+export interface SvgChartThreshold {
+  value: number;
+  color: string;
+  label?: string;
+}
+
+const CHART_HEIGHT = 120;
+const PAD = { top: 16, right: 8, bottom: 20, left: 40 } as const;
+
+// Catmull-Rom spline → cubic bezier approximation for smooth curves
+function catmullRomPath(pts: [number, number][]): string {
+  if (pts.length < 2) return "";
+  let d = `M ${pts[0][0].toFixed(1)},${pts[0][1].toFixed(1)}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[Math.max(0, i - 1)];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[Math.min(pts.length - 1, i + 2)];
+    const cp1x = p1[0] + (p2[0] - p0[0]) / 6;
+    const cp1y = p1[1] + (p2[1] - p0[1]) / 6;
+    const cp2x = p2[0] - (p3[0] - p1[0]) / 6;
+    const cp2y = p2[1] - (p3[1] - p1[1]) / 6;
+    d += ` C ${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
+  }
+  return d;
+}
+
+function niceYTicks(min: number, max: number, count = 4): number[] {
+  if (min === max) return [min];
+  const range = max - min;
+  const rawStep = range / (count - 1);
+  const mag = Math.pow(10, Math.floor(Math.log10(rawStep)));
+  const step = ([1, 2, 5, 10].find(s => s * mag >= rawStep) ?? 10) * mag;
+  const start = Math.floor(min / step) * step;
+  const ticks: number[] = [];
+  for (let i = 0; ; i++) {
+    const v = Math.round((start + i * step) * 1e9) / 1e9;
+    if (v > max + step * 0.01) break;
+    if (v >= min - step * 0.5) ticks.push(v);
+  }
+  return ticks;
+}
+
+// Nice time intervals in milliseconds, ordered smallest to largest
+const NICE_TIME_INTERVALS_MS = [
+  60_000,                // 1 min
+  5  * 60_000,           // 5 min
+  10 * 60_000,           // 10 min
+  15 * 60_000,           // 15 min
+  30 * 60_000,           // 30 min
+  60 * 60_000,           // 1 hour
+  2  * 60 * 60_000,      // 2 hours
+  4  * 60 * 60_000,      // 4 hours
+  6  * 60 * 60_000,      // 6 hours
+  12 * 60 * 60_000,      // 12 hours
+  24 * 60 * 60_000,      // 24 hours
+];
+
+// Generate time-range-aware X-axis ticks snapped to real clock boundaries
+function niceTimeTicks(minT: number, maxT: number, maxTicks = 6): number[] {
+  const range = maxT - minT;
+  if (range <= 0) return [minT];
+
+  const targetInterval = range / (maxTicks - 1);
+  const interval =
+    NICE_TIME_INTERVALS_MS.find(i => i >= targetInterval) ??
+    NICE_TIME_INTERVALS_MS[NICE_TIME_INTERVALS_MS.length - 1];
+
+  // Snap first tick to next interval boundary after minT
+  const start = Math.ceil(minT / interval) * interval;
+  const ticks: number[] = [];
+  for (let t = start; t <= maxT + interval * 0.01; t += interval) {
+    ticks.push(t);
+  }
+  return ticks;
+}
+
+// Format a tick timestamp based on the overall time range
+function formatTickTime(t: number, rangeMs: number): string {
+  const date = new Date(t);
+  if (rangeMs < 2 * 60_000) {
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  }
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+@customElement("svg-line-chart")
+export class SvgLineChart extends LitElement {
+  @property({ attribute: false }) data: SvgChartPoint[] = [];
+  @property() color = "#4dabf7";
+  @property() unit = "";
+  @property({ attribute: false }) thresholds: SvgChartThreshold[] = [];
+
+  private _width = 0;
+  private ro?: ResizeObserver;
+
+  static styles = css`
+    :host {
+      display: block;
+      position: relative;
+    }
+    svg {
+      display: block;
+    }
+    .tooltip {
+      position: absolute;
+      display: none;
+      top: 0;
+      background: var(--card-background-color, #1e1e1e);
+      border: 1px solid var(--divider-color, rgba(255, 255, 255, 0.15));
+      border-radius: 4px;
+      padding: 3px 7px;
+      font-size: 11px;
+      color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+      pointer-events: none;
+      white-space: nowrap;
+      z-index: 10;
+    }
+  `;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.ro = new ResizeObserver(([entry]) => {
+      const w = entry?.contentRect.width ?? 0;
+      if (Math.abs(w - this._width) > 1) {
+        this._width = w;
+        this.requestUpdate();
+      }
+    });
+    this.ro.observe(this);
+    this._width = this.clientWidth;
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.ro?.disconnect();
+  }
+
+  private get cw() {
+    return Math.max(0, this._width - PAD.left - PAD.right);
+  }
+
+  private get ch() {
+    return CHART_HEIGHT - PAD.top - PAD.bottom;
+  }
+
+  private onMouseMove(e: MouseEvent) {
+    if (this.data.length < 2) return;
+
+    const svgEl = this.shadowRoot!.querySelector("svg")!;
+    const rect = svgEl.getBoundingClientRect();
+    const mouseX = e.clientX - rect.left - PAD.left;
+    const cw = this.cw;
+
+    const times = this.data.map(p => p.time.getTime());
+    const minT = times[0];
+    const maxT = times[times.length - 1];
+    const tRange = maxT - minT || 1;
+
+    const fraction = Math.max(0, Math.min(1, mouseX / cw));
+    const targetTime = minT + fraction * tRange;
+
+    // Binary search for nearest point
+    let lo = 0;
+    let hi = this.data.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.data[mid].time.getTime() < targetTime) lo = mid + 1;
+      else hi = mid;
+    }
+    const i =
+      lo > 0 &&
+      Math.abs(this.data[lo - 1].time.getTime() - targetTime) <
+        Math.abs(this.data[lo].time.getTime() - targetTime)
+        ? lo - 1
+        : lo;
+
+    const point = this.data[i];
+    const svgX = PAD.left + ((point.time.getTime() - minT) / tRange) * cw;
+
+    const crosshair = this.shadowRoot!.querySelector<SVGLineElement>(".crosshair");
+    if (crosshair) {
+      crosshair.setAttribute("x1", svgX.toFixed(1));
+      crosshair.setAttribute("x2", svgX.toFixed(1));
+      crosshair.style.display = "";
+    }
+
+    const tooltip = this.shadowRoot!.querySelector<HTMLElement>(".tooltip");
+    if (tooltip) {
+      const timeStr = formatTickTime(point.time.getTime(), tRange);
+      tooltip.textContent = `${timeStr} · ${point.value.toFixed(1)}${this.unit}`;
+      tooltip.style.display = "block";
+      const tipLeft = svgX + 10;
+      tooltip.style.left = `${Math.min(tipLeft, this._width - 150)}px`;
+    }
+  }
+
+  private onMouseLeave() {
+    const crosshair = this.shadowRoot!.querySelector<SVGLineElement>(".crosshair");
+    if (crosshair) crosshair.style.display = "none";
+    const tooltip = this.shadowRoot!.querySelector<HTMLElement>(".tooltip");
+    if (tooltip) tooltip.style.display = "none";
+  }
+
+  render() {
+    if (this._width < 10 || this.data.length < 2) return html``;
+
+    const cw = this.cw;
+    const ch = this.ch;
+
+    const times = this.data.map(p => p.time.getTime());
+    const minT = times[0];
+    const maxT = times[times.length - 1];
+    const tRange = maxT - minT || 1;
+
+    const vals = this.data.map(p => p.value);
+    const rawMin = Math.min(...vals);
+    const rawMax = Math.max(...vals);
+    const vPad = (rawMax - rawMin) * 0.1 || 1;
+    const minV = rawMin - vPad;
+    const maxV = rawMax + vPad;
+    const vRange = maxV - minV;
+
+    // Scale to inner SVG coordinates (origin = top-left of chart area)
+    const sx = (t: number) => ((t - minT) / tRange) * cw;
+    const sy = (v: number) => (1 - (v - minV) / vRange) * ch;
+
+    const pts: [number, number][] = this.data.map(p => [sx(p.time.getTime()), sy(p.value)]);
+    const linePath = catmullRomPath(pts);
+    const areaPath = `${linePath} L ${pts[pts.length - 1][0].toFixed(1)},${ch} L ${pts[0][0].toFixed(1)},${ch} Z`;
+
+    const yTicks = niceYTicks(rawMin, rawMax);
+    const xTicks = niceTimeTicks(minT, maxT);
+
+    return html`
+      <svg
+        width="${this._width}"
+        height="${CHART_HEIGHT}"
+        @mousemove=${this.onMouseMove}
+        @mouseleave=${this.onMouseLeave}
+      >
+        <!-- Y axis labels -->
+        ${yTicks.map(v => {
+          const y = PAD.top + sy(v);
+          if (y < PAD.top - 2 || y > PAD.top + ch + 2) return "";
+          return svg`
+            <text
+              x="${PAD.left - 4}" y="${y}"
+              text-anchor="end" dominant-baseline="middle"
+              font-size="10"
+              fill="var(--secondary-text-color, rgba(255,255,255,0.6))"
+            >${Math.round(v)}${this.unit}</text>
+          `;
+        })}
+
+        <!-- X axis labels -->
+        ${xTicks.map(t => {
+          const x = PAD.left + sx(t);
+          if (x < PAD.left - 1 || x > PAD.left + cw + 1) return "";
+          const isFirst = x < PAD.left + 20;
+          const isLast = x > PAD.left + cw - 20;
+          const anchor = isFirst ? "start" : isLast ? "end" : "middle";
+          return svg`
+            <text
+              x="${x}" y="${PAD.top + ch + 14}"
+              text-anchor="${anchor}"
+              font-size="10"
+              fill="var(--secondary-text-color, rgba(255,255,255,0.6))"
+            >${formatTickTime(t, tRange)}</text>
+          `;
+        })}
+
+        <!-- Inner chart SVG — overflow:hidden clips the data paths -->
+        <svg x="${PAD.left}" y="${PAD.top}" width="${cw}" height="${ch}" overflow="hidden">
+          <!-- Y grid lines -->
+          ${yTicks.map(v => {
+            const y = sy(v);
+            if (y < -2 || y > ch + 2) return "";
+            return svg`
+              <line
+                x1="0" y1="${y}" x2="${cw}" y2="${y}"
+                stroke="var(--divider-color, rgba(255,255,255,0.1))"
+                stroke-width="1"
+              />
+            `;
+          })}
+
+          <!-- X grid lines -->
+          ${xTicks.map(t => {
+            const x = sx(t);
+            if (x < -1 || x > cw + 1) return "";
+            return svg`
+              <line
+                x1="${x}" y1="0" x2="${x}" y2="${ch}"
+                stroke="var(--divider-color, rgba(255,255,255,0.1))"
+                stroke-width="1"
+              />
+            `;
+          })}
+
+          <!-- Area fill -->
+          <path d="${areaPath}" fill="${this.color}33" />
+
+          <!-- Line -->
+          <path d="${linePath}" fill="none" stroke="${this.color}" stroke-width="2" />
+
+          <!-- Threshold lines and labels -->
+          ${this.thresholds.map(th => {
+            const y = sy(th.value);
+            if (y < 0 || y > ch) return "";
+            return svg`
+              <line
+                x1="0" y1="${y}" x2="${cw}" y2="${y}"
+                stroke="${th.color}" stroke-width="1" stroke-dasharray="6,4"
+              />
+              ${th.label
+                ? svg`<text
+                    x="${cw - 4}" y="${y - 4}"
+                    text-anchor="end" font-size="10" fill="${th.color}"
+                  >${th.label}</text>`
+                : ""}
+            `;
+          })}
+        </svg>
+
+        <!-- Crosshair (hidden until hover) -->
+        <line
+          class="crosshair"
+          x1="${PAD.left}" y1="${PAD.top}"
+          x2="${PAD.left}" y2="${PAD.top + ch}"
+          stroke="var(--secondary-text-color, rgba(255,255,255,0.4))"
+          stroke-width="1"
+          style="display:none; pointer-events:none"
+        />
+
+        <!-- Hit area for mouse events (must be last) -->
+        <rect
+          x="${PAD.left}" y="${PAD.top}" width="${cw}" height="${ch}"
+          fill="transparent" style="cursor:crosshair"
+        />
+      </svg>
+      <div class="tooltip"></div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "svg-line-chart": SvgLineChart;
+  }
+}


### PR DESCRIPTION
so that we can support HA theme variables


  New src/svg-chart.ts:
  - niceTimeTicks() — picks the best interval from [1min, 5min, 10min, 15min, 30min, 1h, 2h, 4h, 6h, 12h, 24h] and snaps to real clock
  boundaries
  - formatTickTime() — shows HH:mm:ss for sub-2-minute ranges, HH:mm otherwise (tooltip adapts too)
  - Catmull-Rom smooth curve, nested <svg overflow=hidden> for clipping (avoids SVG+Shadow DOM clipPath ID bug)
  - Direct DOM tooltip updates on mousemove (no re-renders)
  - CSS variables used natively: --divider-color, --secondary-text-color, --card-background-color

  Removed: chart.js, chartjs-adapter-date-fns, date-fns — bundle is ~200KB lighter